### PR TITLE
PermissionInterface isn't AutoCloseable

### DIFF
--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/interfaces/permission/PermissionInterface.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/interfaces/permission/PermissionInterface.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-public interface PermissionInterface extends AutoCloseable {
+public interface PermissionInterface {
 
   PermissionInterface NULL = new PermissionInterface() {
 


### PR DESCRIPTION
Just because it has `close()` doesn't mean it is semantically `AutoCloseable`. It is not meant to be used in a try-with-resources block, so it shouldn't be `AutoCloseable`.