### PR TITLE
Fix corrupt locations being forgotten in prisoner v3 to v4 migration

### DIFF
--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/data/upgrade/prisoner/V3ToV4.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/data/upgrade/prisoner/V3ToV4.java
@@ -38,7 +38,7 @@ public final class V3ToV4 implements DataUpgrader {
   public void upgrade(final ConfigurationSection config, final BetterJailsPlugin plugin) {
     if (!config.contains(LAST_LOCATION_FIELD)) {
       // Location was corrupt, let code in PrisonerDataHandler deal with it.
-      config.set(V4_UNKNOWN_LOCATION_FIELD, true);
+      config.set(V4_UNKNOWN_LOCATION_FIELD, false);
       return;
     }
 


### PR DESCRIPTION
If we set unknown location to true here, then it will just look like an unknown location, and the fact that the location was corrupt will be lost. Instead, we need to *not* mark it as unknown, then code in PrisonerDataHandler will notice the lack of a location while a location is claimed to be known, a situation that means that the location got corrupt.