### PR TITLE
Fix has played before check

### DIFF
--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
@@ -118,7 +118,7 @@ public final class CommandHandler {
     final String executorName = sender.getName();
     final String prisonerName = MoreObjects.firstNonNull(target.getName(), "(unknown)");
 
-    if (!target.hasPlayedBefore()) {
+    if (!target.hasPlayedBefore() && !target.isOnline()) {
       throw new CommandError(
           ctx, CommandError.JAIL_FAILED_PLAYER_NEVER_JOINED,
           CommandError.prisonerVariable(prisonerName),


### PR DESCRIPTION
Apparently Bukkit is silly and returns `false` for `hasPlayedBefore` if the player is currently online and on the server for the first time.