### PR TITLE
Add sentence time modification commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All permissions default to operators only unless otherwise noted.
 * `betterjails.setjail` / Lets the user execute the `/setjail` command.
 * `betterjails.modjail` / Lets the user execute the `/modjail` command.
 * `betterjails.deljail` / Lets the user execute the `/deljail` command.
+* `betterjails.jailtime` / Lets the user execute the `/jailtime` command.
 * `betterjails.receivebroadcast` / Prints in the user's chat when a player has been jailed/unjailed.
 * `betterjails.betterjails` / Lets the user execute the `/betterjails` command. Permission defaults
   to true for all users.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ been online for the required time.
 * `/jail info <player>` / Will print out in the chat some information about the jailed player stored
   in the player data file.
 * `/unjail <player>` / Teleports a jailed player back to where they were when jailed.
+* `/jailtime <player> (add|subtract|set) <time>` / Increase, reduce, or set the sentence time of a prisoner.
 * `/betterjails` / Prints the version of the plugin.
 * `/betterjails reload` / Reloads files into memory.
 * `/betterjails save` / Saves files from memory.

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandError.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandError.java
@@ -36,6 +36,7 @@ public final class CommandError extends ParserException {
   public static final Caption JAIL_FAILED_PLAYER_EXEMPT = Caption.of("jailFailedPlayerExempt");
   public static final Caption INFO_FAILED_PLAYER_NOT_JAILED = Caption.of("infoFailedPlayerNotJailed");
   public static final Caption UNJAIL_FAILED_PLAYER_NOT_JAILED = Caption.of("unjailFailedPlayerNotJailed");
+  public static final Caption JAILTIME_FAILED_PLAYER_NOT_JAILED = Caption.of("jailtime-failed-player-not-jailed");
 
   public static final Caption RESOLVE_JAIL_FAILED = Caption.of("non-existent-jail");
   public static final Caption RESOLVE_PRISONER_FAILED = Caption.of("player-not-imprisoned");

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandError.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandError.java
@@ -34,9 +34,6 @@ public final class CommandError extends ParserException {
 
   public static final Caption JAIL_FAILED_PLAYER_NEVER_JOINED = Caption.of("jailFailedPlayerNeverJoined");
   public static final Caption JAIL_FAILED_PLAYER_EXEMPT = Caption.of("jailFailedPlayerExempt");
-  public static final Caption INFO_FAILED_PLAYER_NOT_JAILED = Caption.of("infoFailedPlayerNotJailed");
-  public static final Caption UNJAIL_FAILED_PLAYER_NOT_JAILED = Caption.of("unjailFailedPlayerNotJailed");
-  public static final Caption JAILTIME_FAILED_PLAYER_NOT_JAILED = Caption.of("jailtime-failed-player-not-jailed");
 
   public static final Caption RESOLVE_JAIL_FAILED = Caption.of("non-existent-jail");
   public static final Caption RESOLVE_PRISONER_FAILED = Caption.of("player-not-imprisoned");

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
@@ -358,7 +358,7 @@ public final class CommandHandler {
 
     final Duration newDuration = prisoner.timeLeft().plus(time);
     final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
-    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), prisoner.jailedBy(), newDuration, prisoner.imprisonmentReason(), false);
+    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), newDuration, prisoner.imprisonmentReason(), false);
     sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(newDuration)));
   }
 
@@ -381,7 +381,7 @@ public final class CommandHandler {
 
     final Duration newDuration = prisoner.timeLeft().minus(time);
     final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
-    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), prisoner.jailedBy(), newDuration, prisoner.imprisonmentReason(), false);
+    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), newDuration, prisoner.imprisonmentReason(), false);
     sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(newDuration)));
   }
 
@@ -403,7 +403,7 @@ public final class CommandHandler {
     }
 
     final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
-    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), prisoner.jailedBy(), time, prisoner.imprisonmentReason(), false);
+    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), time, prisoner.imprisonmentReason(), false);
     sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(time)));
   }
 

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BinaryOperator;
 import java.util.stream.Stream;
 
 import static io.github.emilyydev.betterjails.util.Util.color;
@@ -322,48 +323,31 @@ public final class CommandHandler {
     }, this.plugin);
   }
 
+  public enum JailTimeAction {
+    ADD(Duration::plus),
+    SUBTRACT(Duration::minus),
+    SET((t1, t2) -> t2);
+
+    final BinaryOperator<Duration> op;
+    JailTimeAction(BinaryOperator<Duration> op) {
+      this.op = op;
+    }
+  }
+
   @Permission("betterjails.jailtime")
-  @Command("jailtime <prisoner> add <time>")
-  @CommandDescription("Adds more sentence time to a prisoner")
+  @Command("jailtime <prisoner> <action> <time>")
+  @CommandDescription("Increase, reduce, or modify the sentence time of a prisoner")
   public void jailTimeAdd(
       final CommandContext<CommandSender> ctx,
       final CommandSender sender,
       final ApiPrisoner prisoner,
+      final JailTimeAction action,
       final Duration time
   ) {
-    final Duration newDuration = prisoner.timeLeft().plus(time);
+    final Duration newDuration = action.op.apply(prisoner.timeLeft(), (time));
     final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
     this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), newDuration, prisoner.imprisonmentReason(), false);
     sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(newDuration)));
-  }
-
-  @Permission("betterjails.jailtime")
-  @Command("jailtime <prisoner> subtract <time>")
-  @CommandDescription("Subtracts sentence time from a prisoner")
-  public void jailTimeSubtract(
-      final CommandContext<CommandSender> ctx,
-      final CommandSender sender,
-      final ApiPrisoner prisoner,
-      final Duration time
-  ) {
-    final Duration newDuration = prisoner.timeLeft().minus(time);
-    final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
-    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), newDuration, prisoner.imprisonmentReason(), false);
-    sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(newDuration)));
-  }
-
-  @Permission("betterjails.jailtime")
-  @Command("jailtime <prisoner> set <time>")
-  @CommandDescription("Sets the sentence time of a prisoner")
-  public void jailTimeSet(
-      final CommandContext<CommandSender> ctx,
-      final CommandSender sender,
-      final ApiPrisoner prisoner,
-      final Duration time
-  ) {
-    final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
-    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), time, prisoner.imprisonmentReason(), false);
-    sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(time)));
   }
 
   @Permission("betterjails.betterjails")

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
@@ -156,15 +156,6 @@ public final class CommandHandler {
       final CommandSender sender,
       final ApiPrisoner prisoner
   ) {
-    final String executorName = sender.getName();
-    if (prisoner.released()) {
-      throw new CommandError(
-          ctx, CommandError.INFO_FAILED_PLAYER_NOT_JAILED,
-          CommandError.prisonerVariable(prisoner.nameOr("(unknown)")),
-          CommandError.executorVariable(executorName)
-      );
-    }
-
     final ImmutableLocation lastLocation = prisoner.lastLocationNullable();
     final String lastLocationString = lastLocation == null
         ? color("&cunknown")
@@ -228,14 +219,6 @@ public final class CommandHandler {
       final ApiPrisoner prisoner
   ) {
     final String executorName = sender.getName();
-    if (prisoner.released()) {
-      throw new CommandError(
-          ctx, CommandError.UNJAIL_FAILED_PLAYER_NOT_JAILED,
-          CommandError.prisonerVariable(prisoner.nameOr("(unknown)")),
-          CommandError.executorVariable(sender.getName())
-      );
-    }
-
     this.plugin.prisonerData().releasePrisoner(prisoner, this.server.getOfflinePlayer(prisoner.uuid()), uuidOrNil(sender), executorName, true);
     this.server.broadcast(
         this.configuration.messages().releasePrisonerSuccess(prisoner.nameOr("(unknown)"), executorName),
@@ -348,14 +331,6 @@ public final class CommandHandler {
       final ApiPrisoner prisoner,
       final Duration time
   ) {
-    if (prisoner.released()) {
-      throw new CommandError(
-          ctx, CommandError.JAILTIME_FAILED_PLAYER_NOT_JAILED,
-          CommandError.prisonerVariable(prisoner.nameOr("(unknown)")),
-          CommandError.executorVariable(sender.getName())
-      );
-    }
-
     final Duration newDuration = prisoner.timeLeft().plus(time);
     final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
     this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), newDuration, prisoner.imprisonmentReason(), false);
@@ -371,14 +346,6 @@ public final class CommandHandler {
       final ApiPrisoner prisoner,
       final Duration time
   ) {
-    if (prisoner.released()) {
-      throw new CommandError(
-          ctx, CommandError.JAILTIME_FAILED_PLAYER_NOT_JAILED,
-          CommandError.prisonerVariable(prisoner.nameOr("(unknown)")),
-          CommandError.executorVariable(sender.getName())
-      );
-    }
-
     final Duration newDuration = prisoner.timeLeft().minus(time);
     final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
     this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), newDuration, prisoner.imprisonmentReason(), false);
@@ -394,14 +361,6 @@ public final class CommandHandler {
       final ApiPrisoner prisoner,
       final Duration time
   ) {
-    if (prisoner.released()) {
-      throw new CommandError(
-          ctx, CommandError.JAILTIME_FAILED_PLAYER_NOT_JAILED,
-          CommandError.prisonerVariable(prisoner.nameOr("(unknown)")),
-          CommandError.executorVariable(sender.getName())
-      );
-    }
-
     final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
     this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), time, prisoner.imprisonmentReason(), false);
     sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(time)));
@@ -463,7 +422,7 @@ public final class CommandHandler {
   public ApiPrisoner resolvePrisoner(final CommandContext<CommandSender> ctx, final CommandInput input) {
     final String name = input.readString();
     final ApiPrisoner prisoner = this.plugin.prisonerData().getPrisoner(this.plugin.findUniqueId(name));
-    if (prisoner != null) {
+    if (prisoner != null && !prisoner.released()) {
       return prisoner;
     } else {
       throw new CommandError(ctx, CommandError.RESOLVE_PRISONER_FAILED, CommandError.prisonerVariable(name));

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
@@ -325,7 +325,7 @@ public final class CommandHandler {
 
   @Permission("betterjails.jailtime")
   @Command("jailtime <prisoner> <action> <time>")
-  @CommandDescription("Increase, reduce, or modify the sentence time of a prisoner")
+  @CommandDescription("Increase, reduce, or set the sentence time of a prisoner")
   public void jailTime(
       final CommandContext<CommandSender> ctx,
       final CommandSender sender,

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
@@ -70,6 +70,9 @@ public final class CommandHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger("BetterJails");
 
   private static String durationString(Duration duration) {
+    if (duration.isZero() || duration.isNegative()) {
+      return "0s";
+    }
     final StringBuilder timeLeftBuilder = new StringBuilder();
     duration = appendAndTruncateIfApplicable(duration, ChronoUnit.DAYS, 'd', timeLeftBuilder);
     duration = appendAndTruncateIfApplicable(duration, ChronoUnit.HOURS, 'h', timeLeftBuilder);
@@ -334,6 +337,74 @@ public final class CommandHandler {
         );
       }
     }, this.plugin);
+  }
+
+  @Permission("betterjails.jailtime")
+  @Command("jailtime <prisoner> add <time>")
+  @CommandDescription("Adds more sentence time to a prisoner")
+  public void jailTimeAdd(
+      final CommandContext<CommandSender> ctx,
+      final CommandSender sender,
+      final ApiPrisoner prisoner,
+      final Duration time
+  ) {
+    if (prisoner.released()) {
+      throw new CommandError(
+          ctx, CommandError.JAILTIME_FAILED_PLAYER_NOT_JAILED,
+          CommandError.prisonerVariable(prisoner.nameOr("(unknown)")),
+          CommandError.executorVariable(sender.getName())
+      );
+    }
+
+    final Duration newDuration = prisoner.timeLeft().plus(time);
+    final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
+    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), prisoner.jailedBy(), newDuration, prisoner.imprisonmentReason(), false);
+    sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(newDuration)));
+  }
+
+  @Permission("betterjails.jailtime")
+  @Command("jailtime <prisoner> subtract <time>")
+  @CommandDescription("Subtracts sentence time from a prisoner")
+  public void jailTimeSubtract(
+      final CommandContext<CommandSender> ctx,
+      final CommandSender sender,
+      final ApiPrisoner prisoner,
+      final Duration time
+  ) {
+    if (prisoner.released()) {
+      throw new CommandError(
+          ctx, CommandError.JAILTIME_FAILED_PLAYER_NOT_JAILED,
+          CommandError.prisonerVariable(prisoner.nameOr("(unknown)")),
+          CommandError.executorVariable(sender.getName())
+      );
+    }
+
+    final Duration newDuration = prisoner.timeLeft().minus(time);
+    final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
+    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), prisoner.jailedBy(), newDuration, prisoner.imprisonmentReason(), false);
+    sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(newDuration)));
+  }
+
+  @Permission("betterjails.jailtime")
+  @Command("jailtime <prisoner> set <time>")
+  @CommandDescription("Sets the sentence time of a prisoner")
+  public void jailTimeSet(
+      final CommandContext<CommandSender> ctx,
+      final CommandSender sender,
+      final ApiPrisoner prisoner,
+      final Duration time
+  ) {
+    if (prisoner.released()) {
+      throw new CommandError(
+          ctx, CommandError.JAILTIME_FAILED_PLAYER_NOT_JAILED,
+          CommandError.prisonerVariable(prisoner.nameOr("(unknown)")),
+          CommandError.executorVariable(sender.getName())
+      );
+    }
+
+    final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
+    this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), prisoner.jailedBy(), time, prisoner.imprisonmentReason(), false);
+    sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(time)));
   }
 
   @Permission("betterjails.betterjails")

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
@@ -326,14 +326,14 @@ public final class CommandHandler {
   @Permission("betterjails.jailtime")
   @Command("jailtime <prisoner> <action> <time>")
   @CommandDescription("Increase, reduce, or modify the sentence time of a prisoner")
-  public void jailTimeAdd(
+  public void jailTime(
       final CommandContext<CommandSender> ctx,
       final CommandSender sender,
       final ApiPrisoner prisoner,
       final JailTimeAction action,
       final Duration time
   ) {
-    final Duration newDuration = action.op.apply(prisoner.timeLeft(), (time));
+    final Duration newDuration = action.op.apply(prisoner.timeLeft(), time);
     final OfflinePlayer player = this.server.getOfflinePlayer(prisoner.uuid());
     this.plugin.prisonerData().addJailedPlayer(player, prisoner.jail(), uuidOrNil(sender), sender.getName(), newDuration, prisoner.imprisonmentReason(), false);
     sender.sendMessage(this.configuration.messages().jailtimeSuccess(prisoner.nameOr("(unknown)"), sender.getName(), durationString(newDuration)));

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/commands/CommandHandler.java
@@ -323,17 +323,6 @@ public final class CommandHandler {
     }, this.plugin);
   }
 
-  public enum JailTimeAction {
-    ADD(Duration::plus),
-    SUBTRACT(Duration::minus),
-    SET((t1, t2) -> t2);
-
-    final BinaryOperator<Duration> op;
-    JailTimeAction(BinaryOperator<Duration> op) {
-      this.op = op;
-    }
-  }
-
   @Permission("betterjails.jailtime")
   @Command("jailtime <prisoner> <action> <time>")
   @CommandDescription("Increase, reduce, or modify the sentence time of a prisoner")
@@ -424,5 +413,16 @@ public final class CommandHandler {
   @ExceptionHandler(CommandError.class)
   public void handleCommandError(final CommandSender sender, final CommandError error) {
     sender.sendMessage(error.getMessage());
+  }
+
+  public enum JailTimeAction {
+    ADD(Duration::plus),
+    SUBTRACT(Duration::minus),
+    SET((t1, t2) -> t2);
+
+    final BinaryOperator<Duration> op;
+    JailTimeAction(BinaryOperator<Duration> op) {
+      this.op = op;
+    }
   }
 }

--- a/betterjails/src/main/java/io/github/emilyydev/betterjails/config/BetterJailsConfiguration.java
+++ b/betterjails/src/main/java/io/github/emilyydev/betterjails/config/BetterJailsConfiguration.java
@@ -123,6 +123,7 @@ public final class BetterJailsConfiguration extends AbstractConfiguration {
     private static final String SETJAIL_SUCCESS = "setjailSuccess";
     private static final String MODJAIL_SUCCESS = "modify-jail-success";
     private static final String DELJAIL_SUCCESS = "deljailSuccess";
+    private static final String JAILTIME_SUCCESS = "jailtime-success";
     private static final String RELOAD = "reload";
     private static final String SAVE = "save";
     private static final String LIST_NO_JAILS = "listNoJails";
@@ -187,6 +188,10 @@ public final class BetterJailsConfiguration extends AbstractConfiguration {
 
     public String deleteJailSuccess(final String executorName, final String jail) {
       return formatMessage(DELJAIL_SUCCESS, null, executorName, jail, null, null);
+    }
+
+    public String jailtimeSuccess(final String prisoner, final String executorName, final String duration) {
+      return formatMessage(JAILTIME_SUCCESS, prisoner, executorName, null, duration, null);
     }
 
     public String reloadData(final String executorName) {

--- a/betterjails/src/main/resources/config.yml
+++ b/betterjails/src/main/resources/config.yml
@@ -59,6 +59,13 @@ messages:
   deljailSuccess: "&6Jail removed successfully!"
   delete-jail-failed: "&cAn error occurred while deleting data for jail &4{jail}&c. Check the console for errors."
 
+  # Placeholders for /jailtime:
+  # · {prisoner}: player whose sentence time will be modified.
+  # · {player}: player that executes the command.
+  jailtime-failed-player-not-jailed: "&cCannot modify sentence time of {prisoner}, they are not currently serving a sentence."
+  # · {time}: new sentence time.
+  jailtime-success: "&6Sentence time of &c{prisoner} &6is now &c{time}&6."
+
   # Placeholders for /betterjails reload and /betterjails save:
   # · {player}: player that executes the command.
   reload: "&6Files reloaded successfully!"

--- a/betterjails/src/main/resources/config.yml
+++ b/betterjails/src/main/resources/config.yml
@@ -31,10 +31,6 @@ messages:
   jailSuccess: "&c{prisoner} &6has been jailed by &c{player} &6for &c{time}&6."
   jailFailedPlayerNeverJoined: "&cPlayer &4{prisoner} &cnever joined this server."
   jailFailedPlayerExempt: "&4{prisoner} &ccannot be jailed."
-  # Placeholders for /jail info:
-  # · {prisoner}: player to retrieve the status and info.
-  # · {player}: player that executes the command.
-  infoFailedPlayerNotJailed: "&6The player you are requesting the information from is not currently serving a sentence."
 
   # Generic error messages when resolving a jail or prisoner for a command.
   # Available placeholders:
@@ -47,7 +43,6 @@ messages:
   # · {prisoner}: player to be unjailed.
   # · {player}: player that executes the command.
   unjailSuccess: "&c{prisoner} &6has been unjailed by &c{player}&6."
-  unjailFailedPlayerNotJailed: "&c{prisoner} &6could not be unjailed, player wasn't jailed."
 
   # Placeholders for /setjail, /modjail and /deljail:
   # · {player}: player that executes the command.
@@ -62,7 +57,6 @@ messages:
   # Placeholders for /jailtime:
   # · {prisoner}: player whose sentence time will be modified.
   # · {player}: player that executes the command.
-  jailtime-failed-player-not-jailed: "&cCannot modify sentence time of {prisoner}, they are not currently serving a sentence."
   # · {time}: new sentence time.
   jailtime-success: "&6Sentence time of &c{prisoner} &6is now &c{time}&6."
 


### PR DESCRIPTION
Adds `/jailtime`. Example: `/jailtime rymiel add 1h30m`.
Valid actions are `add`, `subtract`, and `set`.

Closes #9